### PR TITLE
Add bot reminder for patch & major updates

### DIFF
--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   comment-on-approval:
-    if: github.event.review.state === 'approved'
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: Post a comment on approval
@@ -15,4 +15,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_number: ${{ github.event.pull_request.number }}
           body: |
-            Your PR is now approved. Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version. This will ensure CDP deploys the correct version. Thank you.
+            Your PR is now approved. 
+            Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version. 
+            This will ensure CDP deploys the correct version. Thank you.

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -19,4 +19,5 @@ jobs:
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
             If merging a minor version, nothing needs to be done as these are automatically handled and deployed by CDP.  
             This will ensure CDP deploys the correct version.  
+            Full details can be found via the [CDP documentation](https://portal.cdp-int.defra.cloud/documentation/how-to/microservices.md?q=bump%20a%20either%20the%20major%20or%20patch%20version%2C%20push%20a%20commit%20with#versioning-your-microservice).  
             Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -17,5 +17,6 @@ jobs:
           body: |
             **Your PR is now approved 🎉**  
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
+            If merging a minor version, nothing needs to be done as these are automatically handled/deployed by CDP.  
             This will ensure CDP deploys the correct version.  
             Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -17,6 +17,6 @@ jobs:
           body: |
             **Your PR is now approved 🎉**  
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
-            If merging a minor version, nothing needs to be done as these are automatically handled/deployed by CDP.  
+            If merging a minor version, nothing needs to be done as these are automatically handled and deployed by CDP.  
             This will ensure CDP deploys the correct version.  
             Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -15,6 +15,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_number: ${{ github.event.pull_request.number }}
           body: |
-            Your PR is now approved. 
-            Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version. 
-            This will ensure CDP deploys the correct version. Thank you.
+            **Your PR is now approved 🎉**  
+            Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
+            This will ensure CDP deploys the correct version.  
+            Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -15,4 +15,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_number: ${{ github.event.pull_request.number }}
           body: |
-            Your PR is now approved. Before merging, be sure to include either `#patch` or `#major` if merging either a patch or major version to ensure CDP deploys the correct version. Thank you.
+            Your PR is now approved. Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version. This will ensure CDP deploys the correct version. Thank you.

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -19,5 +19,5 @@ jobs:
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
             If merging a minor version, nothing needs to be done as these are automatically handled and deployed by CDP.  
             This will ensure CDP deploys the correct version.  
-            Full details can be found via the [CDP documentation](https://portal.cdp-int.defra.cloud/documentation/how-to/microservices.md?q=bump%20a%20either%20the%20major%20or%20patch%20version%2C%20push%20a%20commit%20with#versioning-your-microservice).  
+            Full details can be found in the [CDP documentation](https://portal.cdp-int.defra.cloud/documentation/how-to/microservices.md?q=bump%20a%20either%20the%20major%20or%20patch%20version%2C%20push%20a%20commit%20with#versioning-your-microservice).  
             Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -17,7 +17,7 @@ jobs:
           body: |
             **Your PR is now approved 🎉**  
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  
-            If merging a minor version, nothing needs to be done as these are automatically handled and deployed by CDP.  
             This will ensure CDP deploys the correct version.  
+            If merging a minor version, nothing needs to be done as these are automatically handled and deployed by CDP.  
             Full details can be found in the [CDP documentation](https://portal.cdp-int.defra.cloud/documentation/how-to/microservices.md?q=bump%20a%20either%20the%20major%20or%20patch%20version%2C%20push%20a%20commit%20with#versioning-your-microservice).  
             Thank you. 👍

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          issue_number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number }}
           body: |
             **Your PR is now approved 🎉**  
             Before merging, be sure to include `#patch` or `#major` in your commit message if merging either a patch or major version.  

--- a/.github/workflows/pr-approval-bot.yaml
+++ b/.github/workflows/pr-approval-bot.yaml
@@ -1,0 +1,18 @@
+name: PR Approval Bot
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  comment-on-approval:
+    if: github.event.review.state === 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post a comment on approval
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue_number: ${{ github.event.pull_request.number }}
+          body: |
+            Your PR is now approved. Before merging, be sure to include either `#patch` or `#major` if merging either a patch or major version to ensure CDP deploys the correct version. Thank you.


### PR DESCRIPTION
To help remind developers to include either `#patch` or `#major` in the commit message before merging a patch or major version, a bot will be triggered via GitHub action to post a comment once a PR has been marked as approved.
