### PR TITLE
Update accelerator script to allow unrelated histories

### DIFF
--- a/accelerator.sh
+++ b/accelerator.sh
@@ -21,8 +21,14 @@ cd "$TEMP_DIR"
 echo "Creating target branch '$TARGET_BRANCH'..."
 git checkout -b "$TARGET_BRANCH"
 
-echo "Pulling template repo into target repo..."
-git pull "$TARGET_BRANCH" main --allow-unrelated-histories
+echo "Adding template repo as a remote..."
+git remote add template "$TEMPLATE_REPO"
+
+echo "Fetching template repo..."
+git fetch template
+
+echo "Merging template repo 'main' branch into '$TARGET_BRANCH'..."
+git merge template/main --allow-unrelated-histories
 
 echo "Pushing new branch to target repo..."
 git push -u origin "$TARGET_BRANCH"

--- a/accelerator.sh
+++ b/accelerator.sh
@@ -14,26 +14,18 @@ TARGET_BRANCH="${3:-template-setup}"
 
 TEMP_DIR=$(mktemp -d)
 
-echo "Cloning template repo without history..."
-git clone --depth=1 "$TEMPLATE_REPO" "$TEMP_DIR"
+echo "Cloning target repo..."
+git clone "$TARGET_REPO" "$TEMP_DIR"
 cd "$TEMP_DIR"
 
-echo "Removing Git history..."
-rm -rf .git
-
-echo "Initialising new Git repo..."
-git init
-git remote add origin "$TARGET_REPO"
+echo "Creating target branch '$TARGET_BRANCH'..."
 git checkout -b "$TARGET_BRANCH"
 
-echo "Adding and committing files..."
-git add .
-git commit -m "Initial commit from fcp-sfd-accelerator into '$TARGET_BRANCH' on $TARGET_REPO"
+echo "Pulling template repo into target repo..."
+git pull "$TARGET_BRANCH" main --allow-unrelated-histories
 
-echo "Pushing to '$TARGET_BRANCH' on target repo..."
+echo "Pushing new branch to target repo..."
 git push -u origin "$TARGET_BRANCH"
-
-echo "fcp-sfd-accelerator has been pushed to branch '$TARGET_BRANCH' on $TARGET_REPO"
 
 cd ..
 rm -rf "$TEMP_DIR"

--- a/accelerator.sh
+++ b/accelerator.sh
@@ -13,25 +13,29 @@ TARGET_REPO="$2"
 TARGET_BRANCH="${3:-template-setup}"
 
 TEMP_DIR=$(mktemp -d)
+TEMPLATE_DIR=$(mktemp -d)
 
 echo "Cloning target repo..."
 git clone "$TARGET_REPO" "$TEMP_DIR"
 cd "$TEMP_DIR"
 
-echo "Creating target branch '$TARGET_BRANCH'..."
+echo "Creating new branch '$TARGET_BRANCH'..."
 git checkout -b "$TARGET_BRANCH"
 
-echo "Adding template repo as a remote..."
-git remote add template "$TEMPLATE_REPO"
+echo "Cloning template repo (accelerator) without history..."
+git clone --depth=1 "$TEMPLATE_REPO" "$TEMPLATE_DIR"
 
-echo "Fetching template repo..."
-git fetch template
+echo "Copying files from template repo to target branch..."
+rsync -av --exclude='.git' "$TEMPLATE_DIR"/ ./
 
-echo "Merging template repo 'main' branch into '$TARGET_BRANCH'..."
-git merge template/main --allow-unrelated-histories
+echo "Adding and committing files..."
+git add .
+git commit -m "Apply fcp-sfd-accelerator template to '$TARGET_BRANCH'"
 
-echo "Pushing new branch to target repo..."
+echo "Pushing branch '$TARGET_BRANCH' to target repo..."
 git push -u origin "$TARGET_BRANCH"
 
+echo "Accelerator template has been applied to branch '$TARGET_BRANCH' on $TARGET_REPO"
+
 cd ..
-rm -rf "$TEMP_DIR"
+rm -rf "$TEMP_DIR" "$TEMPLATE_DIR"


### PR DESCRIPTION
Updating the `accelerator.sh` script to allow for unrelated histories so PRs can be created on the target repo after pulling template repo changes and creating a branch.
