### PR TITLE
chore: pin GitHub Actions to commit SHAs and standardise .npmrc

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -19,12 +19,12 @@
 #     runs-on: ubuntu-latest
 #     steps:
 #       - name: Checkout code
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #         with:
 #           fetch-depth: 0
 
 #       - name: Test code and Create Test Coverage Reports
-#         uses: actions/setup-node@v4
+#         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
 #         with:
 #           node-version: 22
 #           cache: npm
@@ -44,7 +44,7 @@
 #           docker compose -f compose.yaml -f compose.test.yaml run --rm "fcp-sfd-accelerator"
 
 #       - name: SonarQubeScan
-#         uses: SonarSource/sonarqube-scan-action@v5
+#         uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
 #         env: 
 #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           

--- a/.github/workflows/pr-approval-bot.yml
+++ b/.github/workflows/pr-approval-bot.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post a comment on approval
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -18,11 +18,11 @@
 #     runs-on: ubuntu-latest
 #     steps:
 #       - name: Check out code
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 #         with:
 #           fetch-depth: 0 # Depth 0 is required for branch-based versioning
 
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
 #         with:
 #           node-version: 22
 #           cache: npm
@@ -37,11 +37,11 @@
 #           docker compose -f compose.yaml -f compose.test.yaml run --rm "fcp-sfd-accelerator"
 
 #       - name: Publish Hot Fix
-#         uses: DEFRA/cdp-build-action/build-hotfix@main
+#         uses: DEFRA/cdp-build-action/build-hotfix@7fe324bec9987c5a4d0f4724b42e30c282892ceb # main
 #         with:
 #           github-token: ${{ secrets.GITHUB_TOKEN }}
 
 #       - name: SonarQubeScan
-#         uses: SonarSource/sonarqube-scan-action@v5
+#         uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
 #         env: 
 #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@
 #     runs-on: ubuntu-latest
 #     steps:
 #       - name: Check out code
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
 #       - name: Create Test Coverage Reports
 #         run: |
@@ -34,11 +34,11 @@
 #           docker compose -f compose.yaml -f compose.test.yaml run --rm "fcp-sfd-accelerator"
 
 #       - name: SonarQubeScan
-#         uses: SonarSource/sonarqube-scan-action@v5
+#         uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
 #         env: 
 #           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 #       - name: Build and Publish
-#         uses: DEFRA/cdp-build-action/build@main
+#         uses: DEFRA/cdp-build-action/build@7fe324bec9987c5a4d0f4724b42e30c282892ceb # main
 #         with:
 #           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+git-tag-version=false
 save-exact=true
 ignore-scripts=true
 min-release-age=7


### PR DESCRIPTION
# Description

- Pin all GitHub Actions to specific commit SHAs for supply chain security
- Standardise .npmrc with git-tag-version=false, save-exact=true, ignore-scripts=true, min-release-age=7

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity
- [ ] has verified PR branch deploys correctly
- [ ] has commented the version number for test in Jira ticket